### PR TITLE
Conditionally render Cookies link to support Evidon cookies banner

### DIFF
--- a/px-demo-footer.html
+++ b/px-demo-footer.html
@@ -47,11 +47,21 @@ Creates a footer for Predix UI demo pages.
           <a href="https://www.ge.com/digital"><img src="[[importPath]]monogram-wdmk.png" alt="GE Monogram" class=""></a>
         </div>
         <div class="demo-footer__list">
-          <ul class="list-inline list-inline--delimited">
-            <li><a href="https://predix.io/legal" class="actionable actionable--secondary" target="_blank">Legal</a></li>
-            <li><a href="https://www.predix.io/support/article/KB0012081" class="actionable actionable--secondary" target="_blank">Contact Us</a></li>
-            <li>Copyright &copy; General Electric Company. All rights reserved.</li>
-          </ul>
+          <template is="dom-if" if="{{_showCookiesLink}}">
+            <ul class="list-inline list-inline--delimited">
+              <li><a on-click="_openCookiesLink" class="actionable actionable--secondary">Cookies</a></li>
+              <li><a href="https://predix.io/legal" class="actionable actionable--secondary" target="_blank">Legal</a></li>
+              <li><a href="https://www.predix.io/support/article/KB0012081" class="actionable actionable--secondary" target="_blank">Contact Us</a></li>
+              <li>Copyright &copy; General Electric Company. All rights reserved.</li>
+            </ul>
+          </template>
+          <template is="dom-if" if="{{!_showCookiesLink}}">
+            <ul class="list-inline list-inline--delimited">
+              <li><a href="https://predix.io/legal" class="actionable actionable--secondary" target="_blank">Legal</a></li>
+              <li><a href="https://www.predix.io/support/article/KB0012081" class="actionable actionable--secondary" target="_blank">Contact Us</a></li>
+              <li>Copyright &copy; General Electric Company. All rights reserved.</li>
+            </ul>            
+          </template>
         </div>
       </div>
     </footer>
@@ -60,6 +70,35 @@ Creates a footer for Predix UI demo pages.
 
 <script>
   Polymer({
-    is: 'px-demo-footer'
+    is: 'px-demo-footer',
+
+    properties: {
+      /**
+       * Shows the cookies link, which opens up the Evidon config dialog to opt in/out of tracking cookies
+       *
+       * @property _showCookiesLink
+       * @type {Boolean}
+       * @default false
+       * @private
+       */
+      _showCookiesLink: {
+        type: Boolean,
+        value: false
+      }
+    },
+
+    ready: function() {
+      // Enable cookies link if global evidon object is present or if we're on www.predix-ui.com
+      if (window.location.hostname.indexOf('predix-ui.com') >= 0 || window.evidon)
+        this._showCookiesLink = true
+    },
+
+    _openCookiesLink: function() {
+      try {
+        window.evidon.notice.showConsentTool();
+      } catch(err) {
+        console.warn('Evidon notice tool is not available.', err)
+      }
+    }
   });
 </script>


### PR DESCRIPTION
Shows the Cookies link that Evidon mandates on pages where the Evidon object is present OR on predix-ui.com.

If Evidon object detected, footer looks like:
![Screen Shot 2019-04-04 at 1 31 07 pm](https://user-images.githubusercontent.com/4055224/55525726-f0400780-56dd-11e9-8c21-614f2fe97ea1.png)

Otherwise:
![Screen Shot 2019-04-04 at 1 30 44 pm](https://user-images.githubusercontent.com/4055224/55525736-f635e880-56dd-11e9-9acb-939f61fe8a5e.png)
